### PR TITLE
refactor: v1.2.1 backgroundTasks.run() - Remove outer try-catch and finally block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elysia-background",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A background task processing plugin for Elysia.js",
   "author": {
     "name": "STACiA",

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,17 +198,12 @@ export class BackgroundTasks implements IBackgroundTask {
    * @throws Error if any task fails
    */
   public async run(): Promise<void> {
-    try {
-      for (const task of this.tasks) {
-        try {
-          await task.run();
-        } catch (error) {
-          throw new BackgroundTaskError(error, task);
-        }
+    for (const task of this.tasks) {
+      try {
+        await task.run();
+      } catch (error) {
+        throw new BackgroundTaskError(error, task);
       }
-    } finally {
-      // Clear tasks array to prevent memory leaks and avoid re-execution of completed tasks
-      this.tasks = [];
     }
   }
 }


### PR DESCRIPTION
Simplifies the `BackgroundTasks.run()` method by:
- Removing the unnecessary outer try-catch wrapper
- Removing the finally block that cleared the tasks array